### PR TITLE
Add hierarchical memory compression for transformer state

### DIFF
--- a/openai_vpt/agent.py
+++ b/openai_vpt/agent.py
@@ -17,6 +17,7 @@ POLICY_KWARGS = dict(
     attention_heads=16,
     attention_mask_style="clipped_causal",
     attention_memory_size=256,
+    attention_memory_compression=[(32, 1), (32, 3), (32, 9), (32, 27)],
     diff_mlp_embedding=False,
     hidsize=2048,
     img_shape=[128, 128, 3],

--- a/openai_vpt/lib/masked_attention.py
+++ b/openai_vpt/lib/masked_attention.py
@@ -4,6 +4,7 @@ import torch as th
 from torch import nn
 
 import openai_vpt.lib.xf as xf
+from openai_vpt.lib.memory_cull import build_memory_cull_strategy
 from openai_vpt.lib.minecraft_util import store_args
 from openai_vpt.lib.tree_util import tree_map
 
@@ -128,6 +129,7 @@ class MaskedAttention(nn.Module):
         norm="none",
         log_scope="sa",
         use_muP_factor=False,
+        memory_cull=None,
     ):
         super().__init__()
 
@@ -138,6 +140,7 @@ class MaskedAttention(nn.Module):
         if mask == "none":
             mask = None
 
+        self.memory_cull = build_memory_cull_strategy(memory_cull, self.maxlen)
         self.orc_attn = xf.All2All(heads, self.maxlen, mask=mask is not None)
         self.orc_block = xf.SelfAttentionLayer(
             input_size,
@@ -148,6 +151,7 @@ class MaskedAttention(nn.Module):
             norm=norm,
             log_scope=log_scope,
             use_muP_factor=use_muP_factor,
+            state_compressor=self.memory_cull,
         )
 
     def initial_state(self, batchsize: int, device=None):
@@ -161,9 +165,11 @@ class MaskedAttention(nn.Module):
     def forward(self, input_bte, first_bt, state):
         """Forward propagation of a single layer"""
         state_mask, xf_state = state
+        prev_state_mask = state_mask
         t = first_bt.shape[1]
+        updated_mask = state_mask
         if self.mask == "clipped_causal":
-            new_mask, state_mask = get_mask(
+            new_mask, updated_mask = get_mask(
                 first_b11=first_bt[:, [[0]]],
                 state_mask=state_mask,
                 t=t,
@@ -174,6 +180,19 @@ class MaskedAttention(nn.Module):
             )
             self.orc_block.attn.mask = new_mask
         output, xf_state = self.orc_block(input_bte, xf_state)
+        if self.memory_cull is not None:
+            indices = getattr(self.orc_block, "_last_state_indices", None)
+            if indices is None:
+                raise RuntimeError("State compressor did not record indices for the cache update")
+            indices = indices.to(input_bte.device)
+            state_mask = self.memory_cull.update_mask(
+                prev_mask=prev_state_mask,
+                new_len=t,
+                indices=indices,
+                first=first_bt[:, [[0]]],
+            )
+        else:
+            state_mask = updated_mask
 
         return output, (state_mask, xf_state)
 

--- a/openai_vpt/lib/memory_cull.py
+++ b/openai_vpt/lib/memory_cull.py
@@ -1,0 +1,187 @@
+"""Utilities for compressing the transformer memory cache.
+
+The stock VPT transformer keeps a fixed-length FIFO buffer of the last
+``attention_memory_size - timesteps`` key/value pairs.  ``MemoryCullStrategy``
+implements an alternative policy where the cache keeps a hierarchical view of
+past observations: the latest few steps are stored densely, while progressively
+older steps are stored with an increasing stride.  This allows the 128 cache
+slots used by VPT to cover a much longer temporal window without changing the
+overall tensor shapes expected by the transformer.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+try:  # pragma: no cover - torch is required at runtime but not for pure index logic
+    import torch as th
+except ModuleNotFoundError:  # pragma: no cover
+    th = None
+
+
+@dataclass
+class MemoryCullConfig:
+    """Configuration describing how the cache should be thinned.
+
+    ``segments`` is an iterable of ``(length, stride)`` pairs.  The strategy
+    will allocate ``length`` cache slots to each segment and sample historical
+    frames using the given ``stride``.  For example ``(32, 1)`` keeps the latest
+    32 frames densely, whereas ``(32, 9)`` keeps 32 frames spaced nine steps
+    apart.
+    """
+
+    segments: Sequence[Tuple[int, int]]
+
+
+class MemoryCullStrategy:
+    """Selects which cache entries to keep after appending new keys/values."""
+
+    def __init__(self, keep_len: int, segments: Sequence[Tuple[int, int]]):
+        if keep_len <= 0:
+            raise ValueError("keep_len must be positive")
+        if not segments:
+            segments = [(keep_len, 1)]
+        self.keep_len = keep_len
+        self.offsets = self._build_offsets(segments)
+
+    def _build_offsets(self, segments: Sequence[Tuple[int, int]]) -> List[int]:
+        """Construct a list of offsets (oldest -> newest)."""
+        offsets: List[int] = []
+        cursor = 0
+        for length, stride in segments:
+            if length <= 0:
+                continue
+            stride = max(stride, 1)
+            for _ in range(length):
+                offsets.append(-cursor)
+                cursor += stride
+                if len(offsets) >= self.keep_len:
+                    break
+            if len(offsets) >= self.keep_len:
+                break
+        # If the schedule did not provide enough slots, continue stepping with
+        # the last stride so that we always return exactly ``keep_len`` offsets.
+        tail_stride = segments[-1][1] if segments else 1
+        tail_stride = max(tail_stride, 1)
+        while len(offsets) < self.keep_len:
+            offsets.append(-cursor)
+            cursor += tail_stride
+        # ``offsets`` currently goes newest -> oldest; reverse to chronological.
+        offsets.sort()
+        return offsets
+
+    def select_indices(self, total_len: int, new_len: int) -> List[int]:
+        """Return indices (ascending) to keep from a concatenated cache.
+
+        ``total_len`` is the length of ``[prev_cache, new_cache]``.  ``new_len``
+        is the length of the freshly appended segment.  The result always
+        contains ``self.keep_len`` indices (with repeated zeros if there is not
+        enough history).
+        """
+        if total_len <= 0:
+            return [0] * self.keep_len
+
+        new_len = max(0, min(new_len, total_len))
+        keep = min(self.keep_len, total_len)
+
+        # If the full context fits inside the buffer, keep everything and pad
+        # with the oldest element to maintain a fixed length.
+        if keep == total_len:
+            indices = list(range(total_len))
+            if keep < self.keep_len:
+                pad = [0] * (self.keep_len - keep)
+                indices = pad + indices
+            return indices
+
+        # If the new block already fills or exceeds the cache, only the most
+        # recent ``keep`` frames can be stored.
+        if new_len >= keep:
+            indices = list(range(total_len - keep, total_len))
+            return indices
+
+        cutoff = total_len - new_len  # index where the new block starts
+        old_needed = keep - new_len
+        base = total_len - 1
+        old_indices: List[int] = []
+
+        for offset in self.offsets:
+            idx = base + offset
+            if idx < 0:
+                idx = 0
+            if idx >= cutoff:
+                continue
+            if not old_indices or idx != old_indices[-1]:
+                old_indices.append(idx)
+            if len(old_indices) == old_needed:
+                break
+
+        if len(old_indices) < old_needed:
+            missing = old_needed - len(old_indices)
+            start = max(cutoff - missing, 0)
+            filler = list(range(start, cutoff))
+            for idx in filler:
+                if not old_indices or idx != old_indices[-1]:
+                    old_indices.append(idx)
+                if len(old_indices) == old_needed:
+                    break
+            old_indices = old_indices[-old_needed:]
+
+        old_indices = sorted(old_indices)
+        tail = list(range(cutoff, total_len))
+        result = old_indices + tail
+
+        if len(result) < keep:
+            pad = [0] * (keep - len(result))
+            result = pad + result
+        elif len(result) > keep:
+            result = result[-keep:]
+
+        if keep < self.keep_len:
+            pad = [0] * (self.keep_len - keep)
+            result = pad + result
+
+        return result
+
+    def update_mask(
+        self,
+        prev_mask: Optional[th.Tensor],
+        new_len: int,
+        indices: th.Tensor,
+        first: th.Tensor,
+    ) -> th.Tensor:
+        """Rebuild the episodic mask after culling the cache."""
+        if th is None:
+            raise RuntimeError("torch is required to update transformer masks")
+        device = indices.device
+        batch = first.shape[0]
+        if prev_mask is None:
+            prev_mask = th.zeros((batch, 1, self.keep_len), dtype=th.bool, device=device)
+        else:
+            prev_mask = prev_mask.to(device)
+            if prev_mask.shape[-1] != self.keep_len:
+                prev_mask = prev_mask[..., -self.keep_len :]
+        not_first = ~first.to(th.bool)
+        prev_mask = prev_mask & not_first
+        new_mask = prev_mask.new_ones((batch, 1, new_len))
+        full_mask = th.cat([prev_mask, new_mask], dim=-1)
+        max_index = full_mask.shape[-1] - 1
+        idx = indices.clamp(min=0, max=max_index)
+        state_mask = full_mask.index_select(-1, idx)
+        return state_mask
+
+
+def build_memory_cull_strategy(
+    config: Optional[Iterable[Tuple[int, int]]],
+    keep_len: int,
+) -> Optional[MemoryCullStrategy]:
+    """Instantiate a :class:`MemoryCullStrategy` from a user config."""
+    if config is None:
+        return None
+    if isinstance(config, MemoryCullStrategy):
+        return config
+    if isinstance(config, MemoryCullConfig):
+        segments = config.segments
+    else:
+        segments = list(config)
+    segments = [(int(length), int(stride)) for length, stride in segments]
+    return MemoryCullStrategy(keep_len=keep_len, segments=segments)

--- a/openai_vpt/lib/policy.py
+++ b/openai_vpt/lib/policy.py
@@ -113,6 +113,7 @@ class MinecraftPolicy(nn.Module):
         attention_mask_style="clipped_causal",
         attention_heads=8,
         attention_memory_size=2048,
+        attention_memory_compression=None,
         use_pointwise_layer=True,
         pointwise_ratio=4,
         pointwise_use_activation=False,
@@ -179,6 +180,7 @@ class MinecraftPolicy(nn.Module):
             attention_mask_style=attention_mask_style,
             attention_heads=attention_heads,
             attention_memory_size=attention_memory_size,
+            attention_memory_compression=attention_memory_compression,
             n_block=n_recurrence_layers,
         )
 

--- a/openai_vpt/lib/util.py
+++ b/openai_vpt/lib/util.py
@@ -144,6 +144,7 @@ class ResidualRecurrentBlock(nn.Module):
         attention_heads=8,
         attention_memory_size=2048,
         attention_mask_style="clipped_causal",
+        attention_memory_compression=None,
         log_scope="resblock",
         block_number=0,
     ):
@@ -188,6 +189,7 @@ class ResidualRecurrentBlock(nn.Module):
                 log_scope=log_scope + "/sa",
                 use_muP_factor=True,
                 mask=attention_mask_style,
+                memory_cull=attention_memory_compression,
             )
 
     def forward(self, x, first, state):

--- a/openai_vpt/lib/xf.py
+++ b/openai_vpt/lib/xf.py
@@ -301,6 +301,7 @@ class SelfAttentionLayer(AttentionLayerBase):
         dtype="float32",
         norm="layer",
         cache_keep_len=None,
+        state_compressor=None,
         relattn=False,
         log_scope="sa",
         use_muP_factor=False,
@@ -328,6 +329,8 @@ class SelfAttentionLayer(AttentionLayerBase):
                     stride = 1
                 cache_keep_len = stride * attn.maxlen
         self.cache_keep_len = cache_keep_len
+        self.state_compressor = state_compressor
+        self._last_state_indices = None
         self.log_scope = log_scope
         self.use_muP_factor = use_muP_factor
 
@@ -378,7 +381,19 @@ class SelfAttentionLayer(AttentionLayerBase):
             tprev = prev.shape[1]
             startfull = max(tprev - self.cache_keep_len, 0)
             full = th.cat([prev[:, startfull:], new], dim=1)
-            outstate = full[:, max(full.shape[1] - (self.cache_keep_len), 0) :]
+            if self.state_compressor is None:
+                startstate = max(full.shape[1] - self.cache_keep_len, 0)
+                indices = th.arange(startstate, full.shape[1], device=full.device)
+                outstate = full[:, startstate:, :]
+            else:
+                index_list = self.state_compressor.select_indices(full.shape[1], new.shape[1])
+                indices = th.as_tensor(index_list, device=full.device, dtype=th.long)
+                if indices.numel() != self.cache_keep_len:
+                    raise RuntimeError(
+                        f"State compressor must return {self.cache_keep_len} indices, got {indices.numel()}"
+                    )
+                outstate = full.index_select(1, indices)
+            self._last_state_indices = indices
             # To see that the preceding slicing is correct, consider the case
             # that maxlen==1. Then `full` only consists of `new`, and
             # `outstate` is empty

--- a/test_memory_cull.py
+++ b/test_memory_cull.py
@@ -1,0 +1,62 @@
+import pytest
+
+try:
+    import torch as th
+except ModuleNotFoundError as exc:  # pragma: no cover - torch is required for the policy itself
+    pytest.skip("requires torch", allow_module_level=True)
+
+from openai_vpt.lib.memory_cull import MemoryCullStrategy
+
+
+def _diffs(indices):
+    return [b - a for a, b in zip(indices[:-1], indices[1:])]
+
+
+def test_select_indices_multi_scale_pattern():
+    strategy = MemoryCullStrategy(keep_len=128, segments=[(32, 1), (32, 3), (32, 9), (32, 27)])
+    indices = strategy.select_indices(total_len=1500, new_len=1)
+    assert len(indices) == 128
+    assert indices == sorted(indices)
+    assert indices[-1] == 1499
+
+    recent = indices[-33:-1]
+    assert len(recent) == 32
+    assert _diffs(recent) == [1] * 31
+
+    medium = indices[-65:-33]
+    assert len(medium) == 32
+    assert _diffs(medium) == [3] * 31
+
+    long = indices[-97:-65]
+    assert len(long) == 32
+    assert _diffs(long) == [9] * 31
+
+    longest = indices[:32]
+    assert len(longest) == 32
+    assert _diffs(longest) == [27] * 31
+
+
+def test_select_indices_handles_short_history():
+    strategy = MemoryCullStrategy(keep_len=8, segments=[(4, 1), (4, 4)])
+    indices = strategy.select_indices(total_len=3, new_len=1)
+    assert len(indices) == 8
+    assert indices[-1] == 2
+    # The oldest slots are padded with zeros when not enough history exists.
+    assert indices.count(0) >= 2
+
+
+def test_select_indices_large_new_chunk():
+    strategy = MemoryCullStrategy(keep_len=4, segments=[(2, 1), (2, 2)])
+    indices = strategy.select_indices(total_len=10, new_len=6)
+    assert indices == [6, 7, 8, 9]
+
+
+def test_update_mask_matches_indices():
+    strategy = MemoryCullStrategy(keep_len=4, segments=[(2, 1), (2, 2)])
+    prev_mask = th.tensor([[[True, True, False, False]]])
+    indices = th.tensor([0, 1, 2, 3])
+    first = th.tensor([[False]])
+    new_mask = strategy.update_mask(prev_mask, new_len=1, indices=indices, first=first)
+    assert new_mask.shape == (1, 1, 4)
+    # The last slot should be marked as coming from the new chunk.
+    assert new_mask[0, 0, -1]


### PR DESCRIPTION
## Summary
- implement a reusable memory culling strategy so transformer caches can retain multi-scale history while keeping the expected tensor shapes
- wire the strategy into the masked attention layer and expose configuration knobs from the Minecraft policy through the agent defaults
- add unit coverage for the selection schedule and mask updates

## Testing
- pytest test_memory_cull.py *(skipped: requires torch)*

------
https://chatgpt.com/codex/tasks/task_e_68ce67c8a24483289ca4ed501c186637