### PR TITLE
Track transformer cache steps for memory culling

### DIFF
--- a/openai_vpt/lib/masked_attention.py
+++ b/openai_vpt/lib/masked_attention.py
@@ -173,7 +173,7 @@ class MaskedAttention(nn.Module):
                 device=input_bte.device,
             )
             self.orc_block.attn.mask = new_mask
-        output, xf_state = self.orc_block(input_bte, xf_state)
+        output, xf_state = self.orc_block(input_bte, xf_state, first_bt)
 
         return output, (state_mask, xf_state)
 

--- a/openai_vpt/lib/memory_cull.py
+++ b/openai_vpt/lib/memory_cull.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Set, Tuple, Union
 
 import torch as th
 
@@ -114,39 +114,64 @@ class MemoryCullStrategy:
             return MemoryCullSelection(indices=empty, per_tier=[empty.clone() for _ in self.tiers])
 
         valid_steps = steps_row.index_select(0, valid_positions)
-        sorted_steps, order = th.sort(valid_steps, descending=True, stable=True)
-        sorted_positions = valid_positions.index_select(0, order)
+        # Sort by step so we can reason about oldest/newest ordering directly.
+        steps_list: List[Tuple[int, int]] = sorted(
+            zip(valid_steps.tolist(), valid_positions.tolist())
+        )
 
-        tier_last_step: List[Optional[int]] = [None] * len(self.tiers)
-        per_tier: List[List[int]] = [[] for _ in self.tiers]
+        used: List[int] = []
+        used_set: Set[int] = set()
+        per_tier_indices: List[List[int]] = [[] for _ in self.tiers]
 
-        for pos, step in zip(sorted_positions.tolist(), sorted_steps.tolist()):
-            for tier_idx, tier in enumerate(self.tiers):
-                if tier.max_keep == 0:
+        # Tier 0 always keeps the newest frames exactly as requested.
+        first_tier = self.tiers[0]
+        if first_tier.max_keep > 0 and steps_list:
+            newest = steps_list[-first_tier.max_keep :]
+            tier_indices = sorted(pos for _, pos in newest)
+            per_tier_indices[0] = tier_indices
+            used.extend(tier_indices)
+            used_set.update(tier_indices)
+
+        remaining = [entry for entry in steps_list if entry[1] not in used_set]
+
+        for tier_idx, tier in enumerate(self.tiers[1:], start=1):
+            if tier.max_keep == 0 or not remaining:
+                continue
+
+            tier_selected: List[int] = []
+            last_step: Optional[int] = None
+
+            for step_value, pos in remaining:
+                if last_step is not None and step_value - last_step < tier.stride:
                     continue
-                if len(per_tier[tier_idx]) >= tier.max_keep:
-                    continue
-                last = tier_last_step[tier_idx]
-                if last is None or last - step >= tier.stride:
-                    per_tier[tier_idx].append(pos)
-                    tier_last_step[tier_idx] = step
+
+                tier_selected.append(pos)
+                last_step = step_value
+                if len(tier_selected) >= tier.max_keep:
                     break
 
+            if tier_selected:
+                tier_selected.sort()
+                per_tier_indices[tier_idx] = tier_selected
+                used.extend(tier_selected)
+                used_set.update(tier_selected)
+                remaining = [entry for entry in steps_list if entry[1] not in used_set]
+            else:
+                per_tier_indices[tier_idx] = []
+
+        used = sorted(set(used))
+
         per_tier_tensors: List[th.Tensor] = []
-        combined_indices: List[int] = []
-        for indices in per_tier:
-            if indices:
-                sorted_indices = sorted(indices)
+        for tier_indices in per_tier_indices:
+            if tier_indices:
                 per_tier_tensors.append(
-                    th.tensor(sorted_indices, dtype=th.long, device=device)
+                    th.tensor(tier_indices, dtype=th.long, device=device)
                 )
-                combined_indices.extend(sorted_indices)
             else:
                 per_tier_tensors.append(th.empty(0, dtype=th.long, device=device))
 
-        if combined_indices:
-            combined_indices = sorted(set(combined_indices))
-            indices_tensor = th.tensor(combined_indices, dtype=th.long, device=device)
+        if used:
+            indices_tensor = th.tensor(used, dtype=th.long, device=device)
         else:
             indices_tensor = th.empty(0, dtype=th.long, device=device)
 

--- a/openai_vpt/lib/memory_cull.py
+++ b/openai_vpt/lib/memory_cull.py
@@ -138,24 +138,25 @@ class MemoryCullStrategy:
             if tier.max_keep == 0 or not remaining:
                 continue
 
-            tier_selected: List[int] = []
+            tier_selected: List[Tuple[int, int]] = []
             last_step: Optional[int] = None
 
-            for step_value, pos in remaining:
-                if last_step is not None and step_value - last_step < tier.stride:
+            for step_value, pos in reversed(remaining):
+                if last_step is not None and last_step - step_value < tier.stride:
                     continue
 
-                tier_selected.append(pos)
+                tier_selected.append((step_value, pos))
                 last_step = step_value
                 if len(tier_selected) >= tier.max_keep:
                     break
 
             if tier_selected:
-                tier_selected.sort()
-                per_tier_indices[tier_idx] = tier_selected
-                used.extend(tier_selected)
-                used_set.update(tier_selected)
-                remaining = [entry for entry in steps_list if entry[1] not in used_set]
+                tier_selected.reverse()
+                tier_positions = [pos for _, pos in tier_selected]
+                per_tier_indices[tier_idx] = tier_positions
+                used.extend(tier_positions)
+                used_set.update(tier_positions)
+                remaining = [entry for entry in remaining if entry[1] not in used_set]
             else:
                 per_tier_indices[tier_idx] = []
 

--- a/openai_vpt/lib/memory_cull.py
+++ b/openai_vpt/lib/memory_cull.py
@@ -1,0 +1,153 @@
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple, Union
+
+import torch as th
+
+
+@dataclass(frozen=True)
+class MemoryTier:
+    """Configuration for a single culling tier."""
+
+    stride: int
+    max_keep: int
+
+    def __post_init__(self):
+        if self.stride <= 0:
+            raise ValueError("stride must be strictly positive")
+        if self.max_keep < 0:
+            raise ValueError("max_keep must be non-negative")
+
+
+@dataclass
+class MemoryCullSelection:
+    """Selection result for a single batch element."""
+
+    indices: th.Tensor
+    per_tier: List[th.Tensor]
+
+
+class MemoryCullStrategy:
+    """Select cache positions to keep according to multi-tier stride rules."""
+
+    def __init__(self, tiers: Sequence[Union[MemoryTier, Tuple[int, int], dict]]):
+        if not tiers:
+            raise ValueError("At least one tier must be provided")
+        self.tiers: List[MemoryTier] = [self._coerce_tier(tier) for tier in tiers]
+
+    @staticmethod
+    def _coerce_tier(tier: Union[MemoryTier, Tuple[int, int], dict]) -> MemoryTier:
+        if isinstance(tier, MemoryTier):
+            return tier
+        if isinstance(tier, dict):
+            if "stride" not in tier:
+                raise KeyError("Tier dictionaries must include 'stride'")
+            stride = int(tier["stride"])
+            if "max_keep" in tier:
+                max_keep = int(tier["max_keep"])
+            elif "max_length" in tier:
+                max_keep = int(tier["max_length"])
+            else:
+                raise KeyError("Tier dictionaries must include 'max_keep' or 'max_length'")
+            return MemoryTier(stride=stride, max_keep=max_keep)
+        if isinstance(tier, (list, tuple)):
+            if len(tier) != 2:
+                raise ValueError("Tier tuples must have exactly two elements: (stride, max_keep)")
+            stride, max_keep = tier
+            return MemoryTier(stride=int(stride), max_keep=int(max_keep))
+        raise TypeError(f"Unsupported tier specification: {type(tier)!r}")
+
+    def select_indices(
+        self,
+        full: th.Tensor,
+        step_indices: Union[th.Tensor, Sequence[Sequence[int]], None],
+    ) -> List[MemoryCullSelection]:
+        """Return the indices that should be kept for each batch element.
+
+        Args:
+            full: Tensor whose leading dimensions correspond to ``[batch, time]``.
+                Only used for device/shape inference; the contents are ignored.
+            step_indices: Absolute step indices for each cached position. Negative
+                values are treated as invalid and ignored.
+
+        Returns:
+            A list of :class:`MemoryCullSelection` objects, one per batch element.
+        """
+
+        if step_indices is None:
+            if full is None:
+                raise ValueError("Either 'step_indices' or 'full' must be provided")
+            device = full.device
+            batch, time = full.shape[0], full.shape[1]
+            step_indices = (
+                th.arange(time, device=device, dtype=th.long)
+                .unsqueeze(0)
+                .expand(batch, -1)
+            )
+        else:
+            if not th.is_tensor(step_indices):
+                device = full.device if full is not None else None
+                step_indices = th.as_tensor(step_indices, device=device, dtype=th.long)
+            else:
+                if full is not None:
+                    step_indices = step_indices.to(device=full.device)
+                step_indices = step_indices.to(dtype=th.long)
+
+        if step_indices.dim() == 1:
+            step_indices = step_indices.unsqueeze(0)
+        if step_indices.dim() != 2:
+            raise ValueError("'step_indices' must be a rank-2 tensor")
+
+        batch = step_indices.shape[0]
+        if full is not None and full.shape[0] != batch:
+            raise ValueError("Batch dimension of 'full' and 'step_indices' must match")
+
+        selections: List[MemoryCullSelection] = []
+        for b in range(batch):
+            selections.append(self._select_single(step_indices[b]))
+        return selections
+
+    def _select_single(self, steps_row: th.Tensor) -> MemoryCullSelection:
+        device = steps_row.device
+        valid_positions = (steps_row >= 0).nonzero(as_tuple=True)[0]
+        if valid_positions.numel() == 0:
+            empty = th.empty(0, dtype=th.long, device=device)
+            return MemoryCullSelection(indices=empty, per_tier=[empty.clone() for _ in self.tiers])
+
+        valid_steps = steps_row.index_select(0, valid_positions)
+        sorted_steps, order = th.sort(valid_steps, descending=True, stable=True)
+        sorted_positions = valid_positions.index_select(0, order)
+
+        tier_last_step: List[Optional[int]] = [None] * len(self.tiers)
+        per_tier: List[List[int]] = [[] for _ in self.tiers]
+
+        for pos, step in zip(sorted_positions.tolist(), sorted_steps.tolist()):
+            for tier_idx, tier in enumerate(self.tiers):
+                if tier.max_keep == 0:
+                    continue
+                if len(per_tier[tier_idx]) >= tier.max_keep:
+                    continue
+                last = tier_last_step[tier_idx]
+                if last is None or last - step >= tier.stride:
+                    per_tier[tier_idx].append(pos)
+                    tier_last_step[tier_idx] = step
+                    break
+
+        per_tier_tensors: List[th.Tensor] = []
+        combined_indices: List[int] = []
+        for indices in per_tier:
+            if indices:
+                sorted_indices = sorted(indices)
+                per_tier_tensors.append(
+                    th.tensor(sorted_indices, dtype=th.long, device=device)
+                )
+                combined_indices.extend(sorted_indices)
+            else:
+                per_tier_tensors.append(th.empty(0, dtype=th.long, device=device))
+
+        if combined_indices:
+            combined_indices = sorted(set(combined_indices))
+            indices_tensor = th.tensor(combined_indices, dtype=th.long, device=device)
+        else:
+            indices_tensor = th.empty(0, dtype=th.long, device=device)
+
+        return MemoryCullSelection(indices=indices_tensor, per_tier=per_tier_tensors)

--- a/openai_vpt/lib/xf.py
+++ b/openai_vpt/lib/xf.py
@@ -331,13 +331,13 @@ class SelfAttentionLayer(AttentionLayerBase):
         self.log_scope = log_scope
         self.use_muP_factor = use_muP_factor
 
-    def residual(self, X_bte, state):
+    def residual(self, X_bte, state, first=None):
         X_bte = self.ln_x(X_bte)
         Q_bte = self.q_layer(X_bte)
         K_bte = self.k_layer(X_bte)
         V_bte = self.v_layer(X_bte)
-        if state:
-            state, K_bte, V_bte = self.update_state(state, K_bte, V_bte)
+        if state is not None:
+            state, K_bte, V_bte, _ = self.update_state(state, K_bte, V_bte, first=first)
         postproc_closure, Q_bte, K_bte, V_bte = self.attn.preproc_qkv(Q_bte, K_bte, V_bte)
         extra_btT = self.relattn_logits(X_bte, K_bte.shape[1]) if self.relattn else None
         A_bte = attention(
@@ -355,45 +355,105 @@ class SelfAttentionLayer(AttentionLayerBase):
         Aproj_bte = self.proj_layer(A_bte)
         return Aproj_bte, state
 
-    def forward(self, X_bte, state):
-        R_bte, state = self.residual(X_bte, state)
+    def forward(self, X_bte, state, first=None):
+        R_bte, state = self.residual(X_bte, state, first=first)
         return X_bte + R_bte, state
 
     def stateless_forward(self, X_bte):
         out_bte, _state = self.forward(X_bte, None)
         return out_bte
 
-    def update_state(self, state, K_bte, V_bte):
-        def append(prev, new):
-            """
-            Given `prev` keys from cache, and `new` keys,
-            returns (cache, full), where
-            - cache goes into the output state, length chosen so that on the
-                next timestep, there are enough cached timesteps to get the full
-                context of lenth self.maxlen.
-            - full is used for the current forward pass, with length chosen so
-                that the first timestep new[:, 0] gets to see a context of
-                self.maxlen.
-            """
-            tprev = prev.shape[1]
-            startfull = max(tprev - self.cache_keep_len, 0)
-            full = th.cat([prev[:, startfull:], new], dim=1)
-            outstate = full[:, max(full.shape[1] - (self.cache_keep_len), 0) :]
-            # To see that the preceding slicing is correct, consider the case
-            # that maxlen==1. Then `full` only consists of `new`, and
-            # `outstate` is empty
-            return outstate, full
+    def update_state(self, state, K_bte, V_bte, first=None):
+        if state is None:
+            raise ValueError("State must be provided when using cached attention")
 
-        instate_K, instate_V = state
-        outstate_K, K_bte = append(instate_K, K_bte)
-        outstate_V, V_bte = append(instate_V, V_bte)
+        if len(state) == 2:
+            instate_K, instate_V = state
+            device = K_bte.device
+            instate_steps = th.full(
+                (instate_K.shape[0], instate_K.shape[1]),
+                -1,
+                dtype=th.long,
+                device=device,
+            )
+        else:
+            instate_K, instate_V, instate_steps = state
+            device = instate_K.device
+            instate_steps = instate_steps.to(device=device, dtype=th.long)
+
+        bsz, new_t, _ = K_bte.shape
+
+        def _prepare_first(first_tensor):
+            if first_tensor is None:
+                return th.zeros((bsz, new_t), dtype=th.bool, device=device)
+            if not th.is_tensor(first_tensor):
+                first_tensor = th.as_tensor(first_tensor, device=device)
+            first_tensor = first_tensor.to(device=device, dtype=th.bool)
+            if first_tensor.dim() == 1:
+                first_tensor = first_tensor.unsqueeze(1)
+            if first_tensor.dim() != 2:
+                raise ValueError("`first` must be rank 1 or 2")
+            if first_tensor.shape[0] != bsz:
+                raise ValueError(
+                    f"`first` batch dimension {first_tensor.shape[0]} did not match {bsz}"
+                )
+            if first_tensor.shape[1] == 1 and new_t != 1:
+                first_tensor = first_tensor.expand(-1, new_t)
+            elif first_tensor.shape[1] != new_t:
+                raise ValueError(
+                    f"`first` time dimension {first_tensor.shape[1]} did not match {new_t}"
+                )
+            return first_tensor
+
+        first_bt = _prepare_first(first)
+
+        reset_mask = first_bt.any(dim=1)
+        if reset_mask.any():
+            instate_K = instate_K.clone()
+            instate_V = instate_V.clone()
+            instate_steps = instate_steps.clone()
+            instate_K[reset_mask] = 0
+            instate_V[reset_mask] = 0
+            instate_steps[reset_mask] = -1
+
+        if instate_steps.shape[1] == 0:
+            last_step = th.full((bsz,), -1, dtype=th.long, device=device)
+        else:
+            last_step = instate_steps[:, -1]
+
+        new_steps = []
+        for ti in range(new_t):
+            if first_bt[:, ti].any():
+                last_step = th.where(first_bt[:, ti], th.full_like(last_step, -1), last_step)
+            next_step = last_step + 1
+            new_steps.append(next_step)
+            last_step = next_step
+        if new_steps:
+            new_steps = th.stack(new_steps, dim=1)
+        else:
+            new_steps = instate_steps.new_full((bsz, 0), -1)
+
+        startfull = max(instate_K.shape[1] - self.cache_keep_len, 0)
+        prev_K = instate_K[:, startfull:]
+        prev_V = instate_V[:, startfull:]
+        prev_steps = instate_steps[:, startfull:]
+
+        K_full = th.cat([prev_K, K_bte], dim=1)
+        V_full = th.cat([prev_V, V_bte], dim=1)
+        steps_full = th.cat([prev_steps, new_steps], dim=1)
+
+        out_start = max(K_full.shape[1] - self.cache_keep_len, 0)
+        outstate_K = K_full[:, out_start:]
+        outstate_V = V_full[:, out_start:]
+        outstate_steps = steps_full[:, out_start:]
         assert outstate_K.shape[-2] <= self.cache_keep_len
-        return (outstate_K, outstate_V), K_bte, V_bte
+        return (outstate_K, outstate_V, outstate_steps), K_full, V_full, steps_full
 
     def initial_state(self, batchsize, initial_T=0):
         return (
             tu.zeros((batchsize, initial_T, self.x_size), dtype=self.dtype),
             tu.zeros((batchsize, initial_T, self.x_size), dtype=self.dtype),
+            th.full((batchsize, initial_T), -1, dtype=th.long, device=tu.dev()),
         )
 
     def empty_state(self):

--- a/test_memory_cull.py
+++ b/test_memory_cull.py
@@ -1,0 +1,85 @@
+import torch as th
+
+from openai_vpt.lib import xf
+from openai_vpt.lib.memory_cull import MemoryCullStrategy, MemoryTier
+
+
+def _gather(full: th.Tensor, indices: th.Tensor, detach: bool = False) -> th.Tensor:
+    if indices.numel():
+        gathered = full.index_select(1, indices)
+    else:
+        gathered = full[:, :0]
+    return gathered.detach() if detach else gathered
+
+
+def test_memory_cull_respects_real_time_strides():
+    attn = xf.All2All(nhead=1, maxlen=8, mask=True)
+    layer = xf.SelfAttentionLayer(x_size=4, attn=attn, scale=1.0, cache_keep_len=32)
+
+    batch_size = 1
+    state = layer.initial_state(batch_size, initial_T=0)
+
+    tiers = [
+        MemoryTier(stride=1, max_keep=3),
+        MemoryTier(stride=3, max_keep=3),
+        MemoryTier(stride=6, max_keep=2),
+    ]
+    strategy = MemoryCullStrategy(tiers)
+
+    expected_step = -1
+    resets = {0, 11}
+
+    for step in range(24):
+        is_reset = step in resets
+        first_flag = th.tensor([[is_reset]], dtype=th.bool)
+        if is_reset:
+            expected_step = 0
+        else:
+            expected_step += 1
+
+        key = th.full((batch_size, 1, layer.x_size), float(step))
+        value = th.full((batch_size, 1, layer.x_size), float(step))
+
+        state, full_k, full_v, full_steps = layer.update_state(state, key, value, first=first_flag)
+
+        assert full_steps.shape == (batch_size, full_k.shape[1])
+        assert full_steps[0, -1].item() == expected_step
+        if is_reset and full_steps.shape[1] > 1:
+            # Previous episode history should be invalidated.
+            assert th.all(full_steps[0, :-1] < 0)
+
+        selection = strategy.select_indices(full_k, full_steps)[0]
+        device = selection.indices.device
+
+        # Union of tier selections should match the overall index list.
+        concatenated = (
+            th.cat([idx for idx in selection.per_tier if idx.numel() > 0])
+            if selection.per_tier
+            else th.empty(0, dtype=th.long, device=device)
+        )
+        if concatenated.numel():
+            assert th.equal(th.unique(concatenated, sorted=True), selection.indices)
+        else:
+            assert selection.indices.numel() == 0
+
+        for tier, idx_tensor in zip(strategy.tiers, selection.per_tier):
+            assert idx_tensor.numel() <= tier.max_keep
+            if idx_tensor.numel() == 0:
+                continue
+            tier_steps = full_steps[0].index_select(0, idx_tensor)
+            assert bool(th.all(tier_steps[:-1] <= tier_steps[1:]))
+            if tier_steps.numel() > 1:
+                diffs = tier_steps[1:] - tier_steps[:-1]
+                assert bool(th.all(diffs >= tier.stride))
+
+        state = (
+            _gather(full_k, selection.indices, detach=True),
+            _gather(full_v, selection.indices, detach=True),
+            _gather(full_steps, selection.indices),
+        )
+
+        # Ensure state steps mirror the gathered indices exactly.
+        if selection.indices.numel():
+            assert th.equal(state[2], full_steps.index_select(1, selection.indices))
+        else:
+            assert state[2].numel() == 0

--- a/test_memory_cull.py
+++ b/test_memory_cull.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import torch as th
 
 from openai_vpt.lib import xf
@@ -83,3 +85,30 @@ def test_memory_cull_respects_real_time_strides():
             assert th.equal(state[2], full_steps.index_select(1, selection.indices))
         else:
             assert state[2].numel() == 0
+
+
+def test_memory_cull_populates_all_tiers_after_warmup():
+    tiers = [
+        MemoryTier(stride=1, max_keep=32),
+        MemoryTier(stride=3, max_keep=32),
+        MemoryTier(stride=9, max_keep=32),
+        MemoryTier(stride=27, max_keep=32),
+    ]
+    strategy = MemoryCullStrategy(tiers)
+
+    cached_steps: List[int] = []
+    selection = None
+    for step in range(2000):
+        cached_steps.append(step)
+        selection = strategy.select_indices(full=None, step_indices=[cached_steps])[0]
+        keep = selection.indices.tolist()
+        cached_steps = [cached_steps[i] for i in keep]
+
+    assert selection is not None
+
+    total_kept = 0
+    for tier, idx_tensor in zip(tiers, selection.per_tier):
+        assert idx_tensor.numel() == tier.max_keep
+        total_kept += tier.max_keep
+
+    assert len(cached_steps) == total_kept

--- a/test_memory_cull.py
+++ b/test_memory_cull.py
@@ -98,17 +98,47 @@ def test_memory_cull_populates_all_tiers_after_warmup():
 
     cached_steps: List[int] = []
     selection = None
-    for step in range(2000):
-        cached_steps.append(step)
-        selection = strategy.select_indices(full=None, step_indices=[cached_steps])[0]
+    total_steps = 2600
+    snapshot_step = 2000
+    snapshot_mid = None
+    first_full_step = [None] * len(tiers)
+
+    final_tier_steps: List[List[int]] = []
+
+    for step in range(total_steps):
+        full_steps = cached_steps + [step]
+        selection = strategy.select_indices(full=None, step_indices=[full_steps])[0]
         keep = selection.indices.tolist()
-        cached_steps = [cached_steps[i] for i in keep]
+
+        tier_step_lists = [
+            [full_steps[i] for i in tier_indices.tolist()]
+            for tier_indices in selection.per_tier
+        ]
+
+        for idx, (tier, steps_list) in enumerate(zip(tiers, tier_step_lists)):
+            if len(steps_list) == tier.max_keep and first_full_step[idx] is None:
+                first_full_step[idx] = step
+
+        if step == snapshot_step:
+            snapshot_mid = [steps[-1] if steps else -1 for steps in tier_step_lists]
+
+        cached_steps = [full_steps[i] for i in keep]
+        final_tier_steps = tier_step_lists
 
     assert selection is not None
+    assert snapshot_mid is not None
 
     total_kept = 0
-    for tier, idx_tensor in zip(tiers, selection.per_tier):
-        assert idx_tensor.numel() == tier.max_keep
+    for tier, step_list in zip(tiers, final_tier_steps):
+        assert len(step_list) == tier.max_keep
         total_kept += tier.max_keep
 
     assert len(cached_steps) == total_kept
+
+    for earlier, later in zip(first_full_step, first_full_step[1:]):
+        assert earlier is not None and later is not None
+        assert earlier < later
+
+    final_latest = [steps[-1] if steps else -1 for steps in final_tier_steps]
+    for mid, end in zip(snapshot_mid, final_latest):
+        assert end > mid

--- a/visual_memory_cull.py
+++ b/visual_memory_cull.py
@@ -1,0 +1,137 @@
+"""Utility to visualize the multi-tier memory culling schedule.
+
+The script replicates the policy's default compression schedule and shows
+which frames from an input video would be retained at each tier when the
+``MemoryCullStrategy`` is applied. Four OpenCV windows are created—one per
+memory tier—so you can watch frames move through the cache in real time.
+"""
+
+import argparse
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+import cv2
+import numpy as np
+
+from openai_vpt.lib.memory_cull import MemoryCullStrategy, MemoryTier
+
+# Match the policy's default compression schedule (newest -> oldest tiers).
+DEFAULT_SEGMENTS: Sequence[Tuple[int, int]] = (
+    (32, 1),
+    (32, 3),
+    (32, 9),
+    (32, 27),
+)
+
+
+def build_mosaic(frames: Sequence[np.ndarray], tile: int, cols: int) -> np.ndarray:
+    """Arrange frames into a tiled mosaic for visualization."""
+
+    if not frames:
+        return np.zeros((tile, tile, 3), dtype=np.uint8)
+
+    resized = [cv2.resize(frame, (tile, tile)) for frame in frames]
+    rows = (len(resized) + cols - 1) // cols
+    mosaic = np.zeros((rows * tile, cols * tile, 3), dtype=np.uint8)
+
+    for idx, frame in enumerate(resized):
+        row, col = divmod(idx, cols)
+        start_row = row * tile
+        start_col = col * tile
+        mosaic[start_row : start_row + tile, start_col : start_col + tile] = frame
+
+    return mosaic
+
+
+def _select_frames(
+    cache: Sequence[np.ndarray],
+    per_tier: Sequence[Iterable[int]],
+    tiers: Sequence[MemoryTier],
+    blank: np.ndarray,
+) -> List[List[np.ndarray]]:
+    """Map tier selections to concrete frame lists with left padding."""
+
+    if not cache:
+        return [[blank] * tier.max_keep for tier in tiers]
+
+    tier_frames: List[List[np.ndarray]] = []
+    for tier, indices in zip(tiers, per_tier):
+        materialized = [cache[idx] for idx in indices]
+        pad = tier.max_keep - len(materialized)
+        if pad > 0:
+            materialized = [blank] * pad + materialized
+        tier_frames.append(materialized)
+
+    return tier_frames
+
+
+def main(
+    video_path: str,
+    segments: Sequence[Tuple[int, int]] = DEFAULT_SEGMENTS,
+    tile: int = 128,
+    cols: int = 8,
+) -> None:
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise RuntimeError(f"Could not open {video_path}")
+
+    tiers = [MemoryTier(stride=stride, max_keep=length) for length, stride in segments]
+    strategy = MemoryCullStrategy(tiers=tiers)
+
+    cache: List[np.ndarray] = []
+    steps: List[int] = []
+    blank: Optional[np.ndarray] = None
+    next_step = 0
+
+    window_titles = [f"Tier {i + 1} (stride {tier.stride})" for i, tier in enumerate(tiers)]
+
+    try:
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+
+            if blank is None:
+                blank = np.zeros_like(frame)
+
+            full_cache = cache + [frame]
+            full_steps = steps + [next_step]
+            next_step += 1
+
+            selection = strategy.select_indices(full=None, step_indices=[full_steps])[0]
+            keep_indices = selection.indices.tolist()
+
+            cache = [full_cache[i] for i in keep_indices]
+            steps = [full_steps[i] for i in keep_indices]
+
+            index_map = {original: new for new, original in enumerate(keep_indices)}
+            per_tier_indices = []
+            for tier_indices in selection.per_tier:
+                mapped = [index_map[idx.item()] for idx in tier_indices]
+                per_tier_indices.append(mapped)
+
+            assert blank is not None  # for type checkers
+            tier_frames = _select_frames(cache, per_tier_indices, tiers, blank)
+
+            for title, frames in zip(window_titles, tier_frames):
+                mosaic = build_mosaic(frames, tile=tile, cols=cols)
+                cv2.imshow(title, mosaic)
+
+            # ESC to exit early
+            if cv2.waitKey(1) == 27:
+                break
+    finally:
+        cap.release()
+        cv2.destroyAllWindows()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("video", help="Path to the video file to visualize")
+    parser.add_argument("--tile", type=int, default=128, help="Tile size for each thumbnail (pixels)")
+    parser.add_argument("--cols", type=int, default=8, help="Number of columns in each mosaic")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args.video, tile=args.tile, cols=args.cols)


### PR DESCRIPTION
## Summary
- extend the transformer cache state to carry per-slot step indices and reset them on new episodes
- forward the `first` flags through masked attention and add a step-aware memory culling helper
- cover the new behaviour with a regression test that exercises multi-tier stride enforcement

## Testing
- pytest test_memory_cull.py *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68ce72ad66bc8328869b6fec4aea29f5